### PR TITLE
Use main site's URL on multisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ When a login request is delegated to the upstream WordPress site a local cache o
 ## Configuring Cookie Auth
 
 For Cookie auth to work correctly you must create an OAuth 2 application on the upstream WordPress site. Do so using the `home_url( '/hm-delegated-auth-callback' )` as the Callback URL, and configure this plugin with the Client ID in the PHP constant `HM_DELEGATED_AUTH_CLIENT_ID`.
+
+Note that if you are using multisite, this must use the home URL for the main site so that the callback URL is the same for the whole network. Delegated Auth then redirects internally between sites as necessary.

--- a/inc/cookie/namespace.php
+++ b/inc/cookie/namespace.php
@@ -87,6 +87,11 @@ function get_authorize_url() : string {
 		'redirect_uri'  => home_url( '/hm-delegated-auth-callback' ),
 		'response_type' => 'code',
 	];
+
+	if ( is_multisite() ) {
+		$args['redirect_uri'] = add_query_arg( 'site', get_current_blog_id(), network_home_url( '/hm-delegated-auth-callback' ) );
+	}
+
 	return add_query_arg( $args, $authorise_url );
 }
 

--- a/inc/cookie/namespace.php
+++ b/inc/cookie/namespace.php
@@ -29,7 +29,9 @@ function on_login_form() {
  * Load hook to check for the oauth2 redirect request.
  */
 function on_load() {
-	if ( wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ) !== '/hm-delegated-auth-callback' ) {
+	$home_path = wp_parse_url( home_url(), PHP_URL_PATH );
+	$req_path = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+	if ( substr( $req_path, strlen( $home_path ) ) !== '/hm-delegated-auth-callback' ) {
 		return;
 	}
 

--- a/inc/cookie/namespace.php
+++ b/inc/cookie/namespace.php
@@ -92,7 +92,7 @@ function get_authorize_url() : string {
 		$args['redirect_uri'] = add_query_arg( 'site', get_current_blog_id(), network_home_url( '/hm-delegated-auth-callback' ) );
 	}
 
-	return add_query_arg( $args, $authorise_url );
+	return add_query_arg( urlencode_deep( $args ), $authorise_url );
 }
 
 /**

--- a/inc/cookie/namespace.php
+++ b/inc/cookie/namespace.php
@@ -33,6 +33,19 @@ function on_load() {
 		return;
 	}
 
+	if ( is_multisite() && isset( $_GET['site'] ) ) {
+		// Find the site's callback.
+		$site = absint( $_GET['site'] );
+		$url = get_home_url( $site, '/hm-delegated-auth-callback' );
+
+		// Add query arguments to the redirect.
+		wp_parse_str( $_SERVER['QUERY_STRING'], $args );
+		$with_args = remove_query_arg( 'site', add_query_arg( $args, $url ) );
+
+		wp_redirect( $with_args );
+		exit;
+	}
+
 	$code = sanitize_text_field( $_GET['code'] );
 	$auth_user = on_auth_callback( $code );
 	if ( is_wp_error( $auth_user ) ) {

--- a/inc/cookie/namespace.php
+++ b/inc/cookie/namespace.php
@@ -38,6 +38,11 @@ function on_load() {
 	if ( is_multisite() && isset( $_GET['site'] ) ) {
 		// Find the site's callback.
 		$site = absint( $_GET['site'] );
+		$site_data = get_site( $site );
+		if ( empty( $site_data ) ) {
+			return;
+		}
+
 		$url = get_home_url( $site, '/hm-delegated-auth-callback' );
 
 		// Add query arguments to the redirect.

--- a/inc/cookie/namespace.php
+++ b/inc/cookie/namespace.php
@@ -47,7 +47,7 @@ function on_load() {
 
 		// Add query arguments to the redirect.
 		wp_parse_str( $_SERVER['QUERY_STRING'], $args );
-		$with_args = remove_query_arg( 'site', add_query_arg( $args, $url ) );
+		$with_args = remove_query_arg( 'site', add_query_arg( urlencode_deep( $args ), $url ) );
 
 		wp_redirect( $with_args );
 		exit;


### PR DESCRIPTION
To ensure the callback URL is constant across multisite installs, we need to use the main site's URL for all callbacks, and internally handle redirection.