### PR TITLE
Add margin below login with SSO link

### DIFF
--- a/inc/cookie/namespace.php
+++ b/inc/cookie/namespace.php
@@ -20,7 +20,7 @@ function is_enabled() : bool {
  */
 function on_login_form() {
 	if ( defined( 'HM_DELEGATED_AUTH_LOGIN_TEXT' ) && is_string( HM_DELEGATED_AUTH_LOGIN_TEXT ) ) { ?>
-		<p><a href="<?php echo esc_url( get_authorize_url() ); ?>"><?php echo esc_html( HM_DELEGATED_AUTH_LOGIN_TEXT ); ?></a></p>
+		<p style="margin-bottom: 16px;"><a href="<?php echo esc_url( get_authorize_url() ); ?>"><?php echo esc_html( HM_DELEGATED_AUTH_LOGIN_TEXT ); ?></a></p>
 		<?php
 	}
 }


### PR DESCRIPTION
The login with SSO link styling is a bit messy. See screenshot from test site:

![image](https://user-images.githubusercontent.com/494927/56927916-416ccc80-6acd-11e9-86d0-c87d95d40dd1.png)

Looks much better with a margin on the bottom.

![image](https://user-images.githubusercontent.com/494927/56928006-7d079680-6acd-11e9-90c3-2dcd45acb5f2.png)

Note this is pretty much untested :)