### PR TITLE
Don't restrict finding users to curernt blog

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -47,6 +47,7 @@ function get_remote_user_for_token( string $token ) {
 function get_user_from_remote_user_id( int $remote_user_id ) {
 	$users = get_users( [
 		'limit' => 1,
+		'blog_id' => 0,
 		'meta_query' => [
 			[
 				'key'     => "delegated_oauth2_remote_user_id_{$remote_user_id}",


### PR DESCRIPTION
When lokoing for an existing user, don't restrict the matching users to the current site. The user's role will also be approrpiately set in the update function, so there's no need to worry about the case where they need to get added to that site.